### PR TITLE
fix handling source files with invalid utf8: lossy conversion to string

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -332,9 +332,9 @@ fn find_unsafe(
             }
         };
         let mut file = File::open(p).expect("Unable to open file");
-        let mut src = String::new();
-        file.read_to_string(&mut src).expect("Unable to read file");
-        let syntax = match (allow_partial_results, syn::parse_file(&src)) {
+        let mut src = vec![];
+        file.read_to_end(&mut src).expect("Unable to read file");
+        let syntax = match (allow_partial_results, syn::parse_file(&String::from_utf8_lossy(&src))) {
             (_, Ok(s)) => s,
             (true, Err(e)) => {
                 // TODO: Do proper error logging.


### PR DESCRIPTION
Some projects, like [bat](https://github.com/sharkdp/bat) use invalid UTF8 is source files on purpose. This ensures cargo-geiger doesn't crash when `Read::read_to_string` fails due to encoding issues, and still parses the file.