### PR TITLE
Canonicalize file paths from walker

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,8 @@ pub fn find_unsafe(
         if !is_file_with_ext(&entry, "rs") {
             continue;
         }
-        let p = entry.path();
+        let pb = entry.path().canonicalize().expect("Error converting to canonical path");
+        let p = pb.as_path();
         let scan_counter = rs_files_used.get_mut(p);
         vis.used_by_build = match scan_counter {
             Some(c) => {


### PR DESCRIPTION
On Windows 10, the tool does not count files that are actually used in the build, due to a mismatch in the file path representations. 

For example, `cargo geiger -v` gives:

```
Used by build (sorted): \\?\C:\Users\ajpaverd\rust0\src\main.rs
Metric output format: x/y
x = unsafe code used by the build
y = total unsafe code found in the crate
Functions  Expressions  Impls  Traits  Methods  Dependency
Not used in build: C:\Users\ajpaverd\rust0\src\main.rs
0/1        0/1          0/0    0/0     0/0        rust0 v0.1.0 (file:///C:/Users/ajpaverd/rust0)
WARNING: Dependency file was never scanned: \\?\C:\Users\ajpaverd\rust0\src\main.rs
```

I've tested the fixed version on:
- Windows 10
- Windows Subsystem for Linux (Ubuntu 18.04)
- Ubuntu 18.04

I think the fix is quite simple, but please let me know if anything needs to be changed. Thanks!
